### PR TITLE
Include key on span component

### DIFF
--- a/lib/react-diff.js
+++ b/lib/react-diff.js
@@ -38,11 +38,11 @@ module.exports = React.createClass({
 
   render: function () {
     var diff = fnMap[this.props.type](this.props.inputA, this.props.inputB);
-    var result = diff.map(function(part) {
+    var result = diff.map(function(part, index) {
       var spanStyle = {
         backgroundColor: part.added ? 'lightgreen' : part.removed ? 'salmon' : 'lightgrey'
       }
-      return <span style={spanStyle}>{part.value}</span>
+      return <span key={index} style={spanStyle}>{part.value}</span>
     });
     return (
       <pre className='diff-result'>


### PR DESCRIPTION
Hey, thanks for creating this - works like a charm. My only issue is that the `span` components in the `result` array do not have keys. This clutters up the console with warnings when you're debugging something. See [here](http://facebook.github.io/react/docs/multiple-components.html#dynamic-children) for more info.
