### PR TITLE
Add key props

### DIFF
--- a/dist/react-diff.js
+++ b/dist/react-diff.js
@@ -4,10 +4,10 @@ var React = require('react');
 var jsdiff = require('diff');
 
 var fnMap = {
-  chars: jsdiff.diffChars,
-  words: jsdiff.diffWords,
-  sentences: jsdiff.diffSentences,
-  json: jsdiff.diffJson
+  'chars': jsdiff.diffChars,
+  'words': jsdiff.diffWords,
+  'sentences': jsdiff.diffSentences,
+  'json': jsdiff.diffJson
 };
 
 module.exports = React.createClass({
@@ -29,13 +29,13 @@ module.exports = React.createClass({
 
   render: function render() {
     var diff = fnMap[this.props.type](this.props.inputA, this.props.inputB);
-    var result = diff.map(function (part) {
+    var result = diff.map(function (part, index) {
       var spanStyle = {
         backgroundColor: part.added ? 'lightgreen' : part.removed ? 'salmon' : 'lightgrey'
       };
       return React.createElement(
         'span',
-        { style: spanStyle },
+        { key: index, style: spanStyle },
         part.value
       );
     });
@@ -44,5 +44,6 @@ module.exports = React.createClass({
       { className: 'diff-result' },
       result
     );
-  } });
+  }
+});
 

--- a/lib/react-diff.js
+++ b/lib/react-diff.js
@@ -41,7 +41,7 @@ module.exports = React.createClass({
     var result = diff.map(function(part, index) {
       var spanStyle = {
         backgroundColor: part.added ? 'lightgreen' : part.removed ? 'salmon' : 'lightgrey'
-      }
+      };
       return <span key={index} style={spanStyle}>{part.value}</span>
     });
     return (


### PR DESCRIPTION
Rebuilds the module to include the 'key' prop that is missing in the dist version of the module.

The only change in the `lib/react-diff.js` file is the addition a missing semicolon.

This PR addresses issue #5
