### PR TITLE
Remove deprecations

### DIFF
--- a/dist/react-diff.js
+++ b/dist/react-diff.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var jsdiff = require('diff');
 
 var fnMap = {
@@ -10,7 +12,7 @@ var fnMap = {
   'json': jsdiff.diffJson
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Diff',
 
   getDefaultProps: function getDefaultProps() {
@@ -22,9 +24,9 @@ module.exports = React.createClass({
   },
 
   propTypes: {
-    inputA: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
-    inputB: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
-    type: React.PropTypes.oneOf(['chars', 'words', 'sentences', 'json'])
+    inputA: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    inputB: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    type: PropTypes.oneOf(['chars', 'words', 'sentences', 'json'])
   },
 
   render: function render() {
@@ -46,4 +48,3 @@ module.exports = React.createClass({
     );
   }
 });
-

--- a/lib/react-diff.js
+++ b/lib/react-diff.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class')
 var jsdiff = require('diff');
 
 var fnMap = {
@@ -9,7 +10,7 @@ var fnMap = {
   'json': jsdiff.diffJson
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Diff',
 
   getDefaultProps: function() {

--- a/lib/react-diff.js
+++ b/lib/react-diff.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 var jsdiff = require('diff');
 
 var fnMap = {
@@ -20,15 +21,15 @@ module.exports = React.createClass({
   },
 
   propTypes: {
-    inputA: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    inputA: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
-    inputB: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    inputB: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
-    type: React.PropTypes.oneOf([
+    type: PropTypes.oneOf([
       'chars',
       'words',
       'sentences',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Highlight differences between inputs",
   "main": "dist/react-diff.js",
   "scripts": {
-    "build": "./node_modules/.bin/babel lib/react-diff.js > dist/react-diff.js"
+    "build": "babel lib/react-diff.js --out-file dist/react-diff.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": ">=0.12.0"
   },
   "dependencies": {
+    "create-react-class": "^15.6.2",
     "diff": "^1.2.0",
     "prop-types": "^15.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react": ">=0.12.0"
   },
   "dependencies": {
-    "diff": "^1.2.0"
+    "diff": "^1.2.0",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel": "^5.1.10"


### PR DESCRIPTION
Hey,

As of React 0.15.5 `PropTypes` and `React.createClass` are deprecated and as of React 16 officially thrown away from the core.

This PR makes your library compatible again with any version of React >= 0.15.5.